### PR TITLE
Remove spaces after CSV commas.

### DIFF
--- a/submit/views.py
+++ b/submit/views.py
@@ -694,12 +694,12 @@ def project_requeue(request, project):
              permission='authenticated')
 @validate(project=EditableDBThing('project_id', Project, source=MATCHDICT))
 def project_scores(request, project):
-    rows = ['Name, Email, Group ID, Score (On Time), Score']
+    rows = ['Name,Email,Group ID,Score (On Time),Score']
     _, best_ontime, best = project.process_submissions()
     for group, (sub, points) in best.items():
         on_time = best_ontime[group][1] if group in best_ontime else ''
         for user in group.users:
-            rows.append('{}, {}, {}, {}, {}'
+            rows.append('{},{},{},{},{}'
                         .format(user.name, user.username, group.id,
                                 points, on_time))
     disposition = 'attachment; filename="{0}.csv"'.format(project.name)


### PR DESCRIPTION
Hey guys!  Sorry if I'm spamming you today...  But I noticed some spurious spaces when editing a grade sheet in Numbers, and I think this is where they came from.

This is a quick fix.  There's a standard [CSV module](https://docs.python.org/3.6/library/csv.html) (since Python 2.3, it says) that should take care of this and escaping, but I didn't dare change that much without a test environment set up.